### PR TITLE
Bump golang to v1.23

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -14,4 +14,4 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v6
         with:
-          version: v1.59
+          version: v1.61

--- a/Makefile
+++ b/Makefile
@@ -74,8 +74,8 @@ GOLANGCI_LINT ?= $(LOCALBIN)/golangci-lint
 
 ## Tool Versions
 ADDLICENSE_VERSION ?= v1.1.1
-GOIMPORTS_VERSION ?= v0.24.0
-GOLANGCI_LINT_VERSION ?= v1.59.1
+GOIMPORTS_VERSION ?= v0.26.0
+GOLANGCI_LINT_VERSION ?= v1.61.0
 
 .PHONY: addlicense
 addlicense: $(ADDLICENSE) ## Download addlicense locally if necessary.

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/ironcore-dev/ironcore-image
 
-go 1.22.6
+go 1.23.0
 
 require (
 	github.com/containerd/containerd v1.7.22


### PR DESCRIPTION
# Proposed Changes

- Bump golang to v1.23
- Bump golangci-lint to v1.61
- Bump goimports to v0.26.0
