### PR TITLE
Publish and Support Flat IronCore OCI image specification

### DIFF
--- a/OCI-SPEC.md
+++ b/OCI-SPEC.md
@@ -1,0 +1,153 @@
+# IronCore OCI Image Specification
+
+This document defines the OCI image layout and media types expected by the IronCore ecosystem. Operating systems packaged according to this specification are compatible with IronCore's boot and virtualization layers.
+
+## Overview
+
+An IronCore OS image is a custom OCI image, stored and distributed via any OCI-compliant registry. It consists of:
+
+- A **top-level index manifest** describing architecture-specific boot variants.
+- One or more **artifact manifests** that represent specific boot modes (e.g., metal or virtualization).
+- Well-defined **media types** for each component layer.
+
+Following this specification ensures compatibility with the IronCore metal automation system and the IronCore virtualization layer.
+
+---
+
+## Index Manifest
+
+```json
+{
+  "schemaVersion": 2,
+  "mediaType": "application/vnd.oci.image.index.v1+json",
+  "manifests": [
+    {
+      "mediaType": "application/vnd.ironcore.image.artifacts.v1+json",
+      "digest": "sha256:ijkl9012qrst7890uvwx1234yzab5678abcd1234efgh5678mnop3456",
+      "size": 2345,
+      "platform": {
+        "architecture": "amd64",
+        "os": "linux"
+      }
+    },
+    {
+      "mediaType": "application/vnd.ironcore.image.artifacts.v1+json",
+      "digest": "sha256:mnop3456qrst7890uvwx1234yzab5678abcd1234efgh5678ijkl9012",
+      "size": 6789,
+      "platform": {
+        "architecture": "arm64",
+        "os": "linux"
+      }
+    }
+  ]
+}
+```
+
+## Artifact Manifest: Virtualization Boot
+
+```json
+{
+  "schemaVersion": 2,
+  "mediaType": "application/vnd.ironcore.image.artifacts.v1+json",
+  "config": {
+    "mediaType": "application/vnd.ironcore.image.config.v1+json",
+    "digest": "sha256:configdigest1234abcd5678efgh9012ijkl3456mnop7890qrst",
+    "size": 100
+  },
+  "layers": [
+    {
+      "mediaType": "application/vnd.ironcore.image.disk.img",
+      "digest": "sha256:diskimgdigestabcd1234efgh5678ijkl9012mnop3456qrst7890",
+      "size": 1073741824
+    },
+    {
+      "mediaType": "application/vnd.ironcore.image.kernel",
+      "digest": "sha256:kernelabcd1234efgh5678ijkl9012mnop3456qrst7890uvwx1234",
+      "size": 10485760
+    },
+    {
+      "mediaType": "application/vnd.ironcore.image.initramfs",
+      "digest": "sha256:initramfsabcd1234efgh5678ijkl9012mnop3456qrst7890uvwx1234",
+      "size": 20971520
+    },
+    {
+      "mediaType": "application/vnd.ironcore.image.squashfs",
+      "digest": "sha256:squashfsabcd1234efgh5678ijkl9012mnop3456qrst7890uvwx1234",
+      "size": 536870912
+    },
+    {
+      "mediaType": "application/vnd.ironcore.image.cmdline",
+      "digest": "sha256:cmdlineabcd1234efgh5678ijkl9012mnop3456qrst7890uvwx1234",
+      "size": 1024
+    },
+    {
+      "mediaType": "application/vnd.ironcore.image.uki",
+      "digest": "sha256:ukiabcd1234efgh5678ijkl9012mnop3456qrst7890uvwx1234",
+      "size": 15728640
+    },
+    {
+      "mediaType": "application/vnd.ironcore.image.iso",
+      "digest": "sha256:isoabcd1234efgh5678ijkl9012mnop3456qrst7890uvwx1234",
+      "size": 734003200
+    }
+  ],
+  "annotations": {
+    "org.opencontainers.image.title": "MyOS Virtualization (amd64)",
+    "variant": "virtualization",
+    "architecture": "amd64"
+  }
+}
+```
+## Artifact Manifest: Metal Boot
+
+```json
+
+{
+  "schemaVersion": 2,
+  "mediaType": "application/vnd.ironcore.image.artifacts.v1+json",
+  "config": {
+    "mediaType": "application/vnd.ironcore.image.config.v1+json",
+    "digest": "sha256:configdigest5678efgh9012ijkl3456mnop7890qrstabcd1234",
+    "size": 100
+  },
+  "layers": [
+    {
+      "mediaType": "application/vnd.ironcore.image.kernel",
+      "digest": "sha256:kernelabcd1234efgh5678ijkl9012mnop3456qrst7890uvwx1234",
+      "size": 10485760
+    },
+    {
+      "mediaType": "application/vnd.ironcore.image.initramfs",
+      "digest": "sha256:initramfsabcd1234efgh5678ijkl9012mnop3456qrst7890uvwx1234",
+      "size": 20971520
+    },
+    {
+      "mediaType": "application/vnd.ironcore.image.squashfs",
+      "digest": "sha256:squashfsabcd1234efgh5678ijkl9012mnop3456qrst7890uvwx1234",
+      "size": 536870912
+    },
+    {
+      "mediaType": "application/vnd.ironcore.image.cmdline",
+      "digest": "sha256:cmdlineabcd1234efgh5678ijkl9012mnop3456qrst7890uvwx1234",
+      "size": 1024
+    },
+    {
+      "mediaType": "application/vnd.ironcore.image.uki",
+      "digest": "sha256:ukiabcd1234efgh5678ijkl9012mnop3456qrst7890uvwx1234",
+      "size": 15728640
+    },
+    {
+      "mediaType": "application/vnd.ironcore.image.iso",
+      "digest": "sha256:isoabcd1234efgh5678ijkl9012mnop3456qrst7890uvwx1234",
+      "size": 734003200
+    }
+  ],
+  "annotations": {
+    "org.opencontainers.image.title": "MyOS MetalBoot (amd64)",
+    "variant": "metal",
+    "architecture": "amd64"
+  }
+}
+```
+
+

--- a/README.md
+++ b/README.md
@@ -105,6 +105,14 @@ To pull the pushed image, run
 ironcore-image pull ghcr.io/ironcore-dev/ironcore-image/my-image:latest
 ```
 
+## OCI Specification
+
+This project also defines and publishes the OCI image specification that operating systems must conform to in order to be compatible with the IronCore ecosystem.
+
+Following this specification ensures that OS images can be used to boot bare-metal machines via the [metal automation](https://github.com/ironcore-dev/metal-operator) layer and can also be used in virtualized environments within the IronCore virtualization stack.
+
+See the full [OCI image layout specification](OCI-SPEC.md) for details on how to package your OS images for IronCore.
+
 ## Contributing
 
 We'd love to get feedback from you. Please report bugs, suggestions or post questions by opening a GitHub issue.

--- a/REUSE.toml
+++ b/REUSE.toml
@@ -13,6 +13,7 @@ path = [
     "go.mod",
     "go.sum",
     "hack/**",
+    "OCI-SPEC.md",
     "REUSE.toml"
 ]
 precedence = "aggregate"

--- a/image.go
+++ b/image.go
@@ -18,7 +18,6 @@ const (
 	InitRAMFSLayerMediaType = "application/vnd.ironcore.image.initramfs"
 	KernelLayerMediaType    = "application/vnd.ironcore.image.kernel"
 	SquashFSLayerMediaType  = "application/vnd.ironcore.image.squashfs"
-	CmdlineLayerMediaType   = "application/vnd.ironcore.image.cmdline"
 	UKILayerMediaType       = "application/vnd.ironcore.image.uki"
 	ISOLayerMediaType       = "application/vnd.ironcore.image.iso"
 )
@@ -54,7 +53,6 @@ func SetupContext(ctx context.Context) context.Context {
 	ctx = remotes.WithMediaTypeKeyPrefix(ctx, InitRAMFSLayerMediaType, "layer-")
 	ctx = remotes.WithMediaTypeKeyPrefix(ctx, KernelLayerMediaType, "layer-")
 	ctx = remotes.WithMediaTypeKeyPrefix(ctx, SquashFSLayerMediaType, "layer-")
-	ctx = remotes.WithMediaTypeKeyPrefix(ctx, CmdlineLayerMediaType, "layer-")
 	ctx = remotes.WithMediaTypeKeyPrefix(ctx, UKILayerMediaType, "layer-")
 	ctx = remotes.WithMediaTypeKeyPrefix(ctx, ISOLayerMediaType, "layer-")
 	return ctx
@@ -85,8 +83,6 @@ func ResolveImage(ctx context.Context, ociImg image.Image) (*Image, error) {
 			img.RootFS = layer
 		case SquashFSLayerMediaType:
 			img.SquashFS = layer
-		case CmdlineLayerMediaType:
-			img.Cmdline = layer
 		case UKILayerMediaType:
 			img.UKI = layer
 		case ISOLayerMediaType:
@@ -124,8 +120,6 @@ type Image struct {
 	InitRAMFs image.Layer
 	// Kernel is the layer containing the kernel.
 	Kernel image.Layer
-	// Cmdline is a layer containing a kernel command line override.
-	Cmdline image.Layer
 	// UKI is a Unified Kernel Image layer.
 	UKI image.Layer
 	// ISO is a layer containing a bootable ISO image.

--- a/image.go
+++ b/image.go
@@ -13,11 +13,14 @@ import (
 )
 
 const (
-	ConfigMediaType         = "application/vnd.ironcore.image.config.v1alpha1+json"
-	RootFSLayerMediaType    = "application/vnd.ironcore.image.rootfs.v1alpha1.rootfs"
-	InitRAMFSLayerMediaType = "application/vnd.ironcore.image.initramfs.v1alpha1.initramfs"
-	KernelLayerMediaType    = "application/vnd.ironcore.image.vmlinuz.v1alpha1.vmlinuz"
-	SquashFSLayerMediaType  = "application/vnd.ironcore.image.squashfs.v1alpha1.squashfs"
+	ConfigMediaType         = "application/vnd.ironcore.image.config.v1+json"
+	RootFSLayerMediaType    = "application/vnd.ironcore.image.rootfs"
+	InitRAMFSLayerMediaType = "application/vnd.ironcore.image.initramfs"
+	KernelLayerMediaType    = "application/vnd.ironcore.image.kernel"
+	SquashFSLayerMediaType  = "application/vnd.ironcore.image.squashfs"
+	CmdlineLayerMediaType   = "application/vnd.ironcore.image.cmdline"
+	UKILayerMediaType       = "application/vnd.ironcore.image.uki"
+	ISOLayerMediaType       = "application/vnd.ironcore.image.iso"
 )
 
 type Config struct {
@@ -51,6 +54,9 @@ func SetupContext(ctx context.Context) context.Context {
 	ctx = remotes.WithMediaTypeKeyPrefix(ctx, InitRAMFSLayerMediaType, "layer-")
 	ctx = remotes.WithMediaTypeKeyPrefix(ctx, KernelLayerMediaType, "layer-")
 	ctx = remotes.WithMediaTypeKeyPrefix(ctx, SquashFSLayerMediaType, "layer-")
+	ctx = remotes.WithMediaTypeKeyPrefix(ctx, CmdlineLayerMediaType, "layer-")
+	ctx = remotes.WithMediaTypeKeyPrefix(ctx, UKILayerMediaType, "layer-")
+	ctx = remotes.WithMediaTypeKeyPrefix(ctx, ISOLayerMediaType, "layer-")
 	return ctx
 }
 
@@ -79,6 +85,12 @@ func ResolveImage(ctx context.Context, ociImg image.Image) (*Image, error) {
 			img.RootFS = layer
 		case SquashFSLayerMediaType:
 			img.SquashFS = layer
+		case CmdlineLayerMediaType:
+			img.Cmdline = layer
+		case UKILayerMediaType:
+			img.UKI = layer
+		case ISOLayerMediaType:
+			img.ISO = layer
 		default:
 			return nil, fmt.Errorf("unknown layer type %q", layer.Descriptor().MediaType)
 		}
@@ -112,4 +124,10 @@ type Image struct {
 	InitRAMFs image.Layer
 	// Kernel is the layer containing the kernel.
 	Kernel image.Layer
+	// Cmdline is a layer containing a kernel command line override.
+	Cmdline image.Layer
+	// UKI is a Unified Kernel Image layer.
+	UKI image.Layer
+	// ISO is a layer containing a bootable ISO image.
+	ISO image.Layer
 }


### PR DESCRIPTION
# Proposed Changes

Initial IronCore OCI image specification added with support for flat OCI images.
Architecture-aware index-based support will be introduced in a future update.
Consumers like boot-operator will handle both formats based on the Index manifest's existence.

Partially solves: #101 
